### PR TITLE
Avoid calling std::move in return statements

### DIFF
--- a/poly_containers.cpp
+++ b/poly_containers.cpp
@@ -151,7 +151,7 @@ public:
   F for_each(F f)
   {
     for(const auto& p:chunks)p.second->for_each(f);
-    return std::move(f);
+    return f;
   }
 
   template<typename F>
@@ -159,7 +159,7 @@ public:
   {
     for(const auto& p:chunks)
       const_cast<const segment&>(*p.second).for_each(f);
-    return std::move(f);
+    return f;
   }
 
 private:


### PR DESCRIPTION
This prevents RVO. See https://www.reddit.com/r/cpp/comments/3w3fku/mind_the_cache/cxtlsme.
